### PR TITLE
Fix duplicates in the emoticons dropdown

### DIFF
--- a/cosmo/sceditor/event/sce.php
+++ b/cosmo/sceditor/event/sce.php
@@ -65,7 +65,8 @@ class sce implements EventSubscriberInterface
 		}
 		// We need to get all smilies with url and code
 		$sql = 'SELECT smiley_url, code
-			FROM ' . SMILIES_TABLE;
+			FROM ' . SMILIES_TABLE . '
+			GROUP BY smiley_url';
 		// Caching the smilies for 10 minutes should be okay
 		// they don't get changed so often
 		$result = $this->db->sql_query($sql, 600);


### PR DESCRIPTION
Group emoticons by URL to avoid duplicates in the sceditor emoticons dropdown.