### PR TITLE
Fix #13 invisible table borders in edit area

### DIFF
--- a/cosmo/sceditor/styles/all/template/js/themes/editarea.css
+++ b/cosmo/sceditor/styles/all/template/js/themes/editarea.css
@@ -28,3 +28,12 @@ blockquote cite {
 blockquote.uncited {
 	padding-top: 25px;
 }
+/* Visible table borders */
+table {
+	border-collapse: collapse;
+}
+td {
+	border: solid 1px Black;
+	padding: 5px;
+	min-width: 25px;
+}


### PR DESCRIPTION
Make tables more usable by setting a solid black 1px border and also
increasing intial empty cells size (by padding them and setting a
minimal width).